### PR TITLE
Fix MapData name overlap

### DIFF
--- a/MappingThread.py
+++ b/MappingThread.py
@@ -1,14 +1,14 @@
 import math
 import threading
-from multiprocessing import Process, Queue
 import time
+from multiprocessing import Process, Queue
 
 from PyQt5 import QtCore
 from PyQt5.QtCore import pyqtSignal
 from scipy.misc import imresize
 
+import map_data
 import MapBox
-import MapData
 from SubpacketIDs import SubpacketEnum
 
 # Scaling is linear so a scale factor of 1 means no scaling (aka 1*x=x)
@@ -18,14 +18,14 @@ class MappingThread(QtCore.QThread):
     sig_received = pyqtSignal()
     sig_print = pyqtSignal(str)
 
-    def __init__(self, connection, m: MapData.MapDataClass, data, parent=None) -> None:
+    def __init__(self, connection, m: map_data.MapData, data, parent=None) -> None:
         """Mapping work and processing that gets put into MapData, repeatedly as RocketData is updated.
         Signals the main thread to fetch UI elements in MapDataSimilar to ReadData.
 
         :param connection:
         :type connection:
         :param map:
-        :type map: MapData.MapDataClass
+        :type map: map_data.MapData
         :param data:
         :type data:
         :param parent:
@@ -96,8 +96,8 @@ class MappingThread(QtCore.QThread):
         if longitude is None or latitude is None:
             return False
 
-        radius = self.map.getMapValue(MapData.RADIUS)
-        zoom = self.map.getMapValue(MapData.ZOOM)
+        radius = self.map.getMapValue(map_data.RADIUS)
+        zoom = self.map.getMapValue(map_data.ZOOM)
 
         # Create MapPoints that correspond to corners of a square area (of side length 2*radius) surrounding the
         # inputted latitude and longitude.
@@ -131,8 +131,8 @@ class MappingThread(QtCore.QThread):
         mark = (x * resizedMapImage.shape[0], y * resizedMapImage.shape[1])
 
         # TODO NOT ROBUST: What if mapdata updated between top of this function and this setMap
-        self.map.setMapValue(MapData.IMAGE, resizedMapImage)
-        self.map.setMapValue(MapData.MARK, mark)
+        self.map.setMapValue(map_data.IMAGE, resizedMapImage)
+        self.map.setMapValue(map_data.MARK, mark)
 
         return True
 

--- a/main.py
+++ b/main.py
@@ -10,14 +10,14 @@ from PyQt5 import QtCore, QtGui, QtWidgets, uic
 from PyQt5.QtCore import pyqtSignal
 from scipy.misc import imresize
 
+import map_data
 import MapBox
-import MapData
 import MappingThread
 import mplwidget  # DO NOT REMOVE pyinstller needs this
 import ReadThread
 import SendThread
 from detail import LOCAL
-from MapData import MapDataClass
+from map_data import MapData
 from RocketData import RocketData
 from SubpacketIDs import SubpacketEnum
 
@@ -50,7 +50,7 @@ class MainApp(QtWidgets.QMainWindow, Ui_MainWindow):
         # TODO move this set of fields out to application.py
         self.connection = connection
         self.data = RocketData()
-        self.map = MapDataClass()
+        self.map = MapData()
 
         QtWidgets.QMainWindow.__init__(self)
         Ui_MainWindow.__init__(self)
@@ -183,7 +183,7 @@ class MainApp(QtWidgets.QMainWindow, Ui_MainWindow):
             if isinstance(c, AnnotationBbox):
                 c.remove()
 
-        mapImage = self.map.getMapValue(MapData.IMAGE)
+        mapImage = self.map.getMapValue(map_data.IMAGE)
 
         # plotMap UI modification
         self.plotWidget.canvas.ax.set_axis_off()
@@ -201,7 +201,7 @@ class MainApp(QtWidgets.QMainWindow, Ui_MainWindow):
         self.im = self.plotWidget.canvas.ax.imshow(mapImage)
 
         # updateMark UI modification
-        mark = self.map.getMapValue(MapData.MARK)
+        mark = self.map.getMapValue(map_data.MARK)
         annotation_box = AnnotationBbox(OffsetImage(MAP_MARKER), mark, frameon=False)
         self.plotWidget.canvas.ax.add_artist(annotation_box)
 

--- a/map_data.py
+++ b/map_data.py
@@ -6,7 +6,7 @@ IMAGE = '_image'
 MARK = '_mark'
 
 
-class MapDataClass:  # TODO Is there a better way of differentiating from the filename? Its causing trouble when trying to use both
+class MapData:
     def __init__(self) -> None:
         """
 


### PR DESCRIPTION
Just a small naming change to address a TODO in MapData.py. Changed file name to map_data.py, class name to MapData, and refactored references to each. This way we can avoid appending the redundant "Class" to the class's name and be a bit more in line with PEP 8 conventions.