### PR TITLE
Remove TILES, switch from SciPy to Pillow for marker resize

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from matplotlib import pyplot as plt
 from matplotlib.offsetbox import AnnotationBbox, OffsetImage
 from PyQt5 import QtCore, QtGui, QtWidgets, uic
 from PyQt5.QtCore import pyqtSignal
-from scipy.misc import imresize
+from PIL import Image
 
 import map_data
 import MapBox
@@ -31,11 +31,8 @@ qtCreatorFile = os.path.join(LOCAL, "main.ui")
 
 Ui_MainWindow, QtBaseClass = uic.loadUiType(qtCreatorFile)
 
-TILES = 14  # TODO Remove if not necessary
-
 # The marker image, used to show where the rocket is on the map UI
-# TODO: imresize removed in latest scipy since it's a duplicate from "Pillow". Update and replace.
-MAP_MARKER = imresize(plt.imread(MapBox.MARKER_PATH), (12, 12))
+MAP_MARKER = Image.open(MapBox.MARKER_PATH).resize((12, 12), Image.LANCZOS)
 
 
 class MainApp(QtWidgets.QMainWindow, Ui_MainWindow):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 digi_xbee==1.1.1.1
-Pillow==6.1.0
+Pillow==7.2.0
 numpy==1.15.4
-scipy==1.2.0
 matplotlib==3.0.2
 PyQt5==5.12.1
 pyserial==3.4


### PR DESCRIPTION
- Removed TILES constant, which is no longer referenced anywhere in the codebase.
- Moved from SciPy's depricated imresize to Pillow's resize method.
- Removed SciPy from requirements.txt and moved to the latest Pillow version.