### PR TITLE
Fix variable passing in send() and broadcast()

### DIFF
--- a/connections/serial/serial_connection.py
+++ b/connections/serial/serial_connection.py
@@ -30,10 +30,10 @@ class SerialConnection(Connection):
 
     def send(self, device_address, data):
         remote_device = RemoteXBeeDevice(self.device, XBee64BitAddress.from_hex_string(device_address))
-        self.device.send_data(remote_device, bytes)
+        self.device.send_data(remote_device, data)
 
     def broadcast(self, data):
-        self.device.send_data_broadcast(bytes)
+        self.device.send_data_broadcast(data)
 
     def shutdown(self):
         self.device.close()


### PR DESCRIPTION
Fixes the following error when startup the GS using the serial option:

![stack trace](https://user-images.githubusercontent.com/65629579/166166386-367a569f-5304-4bff-a095-593df6c5d2e9.PNG)