### PR TITLE
Workaround for xbee install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-digi_xbee==1.1.1.1
+git+https://github.com/digidotcom/xbee-python@1.1.1#egg=digi-xbee
 Pillow==7.2.0
 numpy==1.15.4
 matplotlib==3.0.2


### PR DESCRIPTION
To fix the error **Could not find a version that satisfies the requirement digi-xbee==1.1.1** for newer versions of pip, we can pull directly from the github to satisfy the requirement.