### PR TITLE
Allow CI to use Python 3.10

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -20,6 +20,7 @@ export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 
 # Start setting up Python for GS
 sudo apt-get install -y tk-dev
+pyenv install --list
 env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.10.6
 pyenv global 3.10.6
 python --version

--- a/ci.sh
+++ b/ci.sh
@@ -20,9 +20,10 @@ export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 
 # Start setting up Python for GS
 sudo apt-get install -y tk-dev
+cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
 pyenv install --list
-env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.10.6
-pyenv global 3.10.6
+env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.10.8
+pyenv global 3.10.8
 python --version
 python -m pip install --upgrade pip setuptools wheel
 

--- a/ci.sh
+++ b/ci.sh
@@ -20,6 +20,7 @@ export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 
 # Start setting up Python for GS
 sudo apt-get install -y tk-dev
+cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
 env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.10.8
 pyenv global 3.10.8
 python --version

--- a/ci.sh
+++ b/ci.sh
@@ -20,9 +20,8 @@ export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 
 # Start setting up Python for GS
 sudo apt-get install -y tk-dev
-env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.7.9
-pyenv update
-pyenv global 3.7.9
+env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.10.6
+pyenv global 3.10.6
 python --version
 python -m pip install --upgrade pip setuptools wheel
 

--- a/ci.sh
+++ b/ci.sh
@@ -20,8 +20,6 @@ export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
 
 # Start setting up Python for GS
 sudo apt-get install -y tk-dev
-cd /opt/circleci/.pyenv/plugins/python-build/../.. && git pull && cd -
-pyenv install --list
 env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 3.10.8
 pyenv global 3.10.8
 python --version


### PR DESCRIPTION
Pulls new python versions so that 3.10 can be installed for CI

Looks like mapbox tests are now failing, which is consistent with what we saw using 3.10 locally in the past week