### PR TITLE
Add dependency install action

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,10 +14,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pylint
+    - name: Python Dependency Installation
+      uses: py-actions/py-dependency-install@v4.0.0
+      with:
+        path: "../../requirements.txt"
+        update-pip: "false"
+        update-setuptools: "false"
+        update-wheel: "false"
     - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@v11.5

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -14,13 +14,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Python Dependency Installation
-      uses: py-actions/py-dependency-install@v4.0.0
-      with:
-        path: "../../requirements.txt"
-        update-pip: "false"
-        update-setuptools: "false"
-        update-wheel: "false"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
     - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@v11.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-digi_xbee==1.1.1.1
+git+https://github.com/digidotcom/xbee-python@1.1.1#egg=digi-xbee
 Pillow==7.2.0
 numpy==1.15.4
 matplotlib==3.0.2


### PR DESCRIPTION
The new GitHub action that lints changes does not install all GS dependencies. This results in packages not being found when linting.

Fix: Install deps from requirements.txt in the pylint action